### PR TITLE
Fix: Model viewer not loading due to JavaScript error

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -194,8 +194,11 @@ document.addEventListener('DOMContentLoaded', () => {
      */
     const showArModal = () => {
         if (!currentArItem) return;
-        detailsModal.style.display = 'none';
-        modelViewer.src = currentArItem.model_url;
+        modelViewer.setAttribute('src', currentArItem.model_url);
+        // The ios-src attribute is used for AR Quick Look on iOS devices
+        if (modelViewer.hasAttribute('ios-src')) {
+            modelViewer.setAttribute('ios-src', currentArItem.model_url.replace(/\.glb$/, '.usdz'));
+        }
         arItemName.textContent = currentArItem.name;
         arItemDescription.textContent = currentArItem.description;
         arModal.style.display = 'flex';


### PR DESCRIPTION
The model viewer was failing to load because of a `ReferenceError` in the `showArModal` function. The function was trying to access an undefined variable `detailsModal`. I removed the erroneous line to fix this.

I also improved the model viewer functionality by:
- Using `setAttribute` to set the model's `src`, which is a more robust method for custom elements.
- Adding support for iOS AR Quick Look by setting the `ios-src` attribute.